### PR TITLE
Prefer const whenever possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,6 @@ module.exports = {
     'no-multiple-empty-lines': ["error", { max: 2, maxEOF: 1, maxBOF: 0 }], //only one empty line allowed, none at the start of a file
     'curly': ["error", "all"], //prevent single line blocks without curlys
     "sort-imports": 2, //sort imports alphabetically
+    "prefer-const": "error", //const > let
   },
 };


### PR DESCRIPTION
From rule docs:
If a variable is never reassigned, using the `const` declaration is better.
`const` declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.